### PR TITLE
fix: pin web-animations-js to 2.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "hammerjs": "^2.0.8",
     "ng2-charts": "^1.6.0",
     "rxjs": "^5.1.0",
-    "web-animations-js": "^2.2.5",
+    "web-animations-js": "2.2.5",
     "zone.js": "^0.8.4"
   },
   "devDependencies": {


### PR DESCRIPTION
fix breaking web-animations-js see #6 